### PR TITLE
Fix encoding error in toResponse

### DIFF
--- a/src/Servant/Client/Internal/JSaddleXhrClient.hs
+++ b/src/Servant/Client/Internal/JSaddleXhrClient.hs
@@ -282,7 +282,7 @@ toResponse domc xhr = do
     _ -> inDom $ do
       statusText <- BS.pack <$> JS.getStatusText xhr
       headers <- parseHeaders <$> JS.getAllResponseHeaders xhr
-      responseText <- maybe "" (L.fromStrict . BS.pack) <$> JS.getResponseText xhr -- FIXME: Text/Binary? Performance? Test?
+      responseText <- maybe "" (L.fromStrict . T.encodeUtf8) <$> JS.getResponseText xhr
       pure Response
         { responseStatusCode  = mkStatus (fromIntegral status) statusText
         , responseBody        = responseText


### PR DESCRIPTION
The old code uses `Data.ByteString.Char8.pack` which destroys unicode.
Example:
```
ghci> Data.ByteString.Char8.pack "\9679"
"\207"
```
The return value of `JS.getResponseText` is overloaded to return something
of type `FromJSString result => Maybe result`.

There's no instance `FromJSString ByteString` in scope so the next best thing
is the `Text` instance.

This actually came up in my project and this patch fixed it.