### PR TITLE
Update for new GHC JS backend

### DIFF
--- a/servant-jsaddle.cabal
+++ b/servant-jsaddle.cabal
@@ -72,7 +72,7 @@ library
     , string-conversions  >=0.3     && <0.5
     , transformers-base   >=0.4.4   && <0.5
 
-  if impl(ghc >=8.0) || arch(javascript)
+  if impl(ghc >=8.0)
     ghc-options: -Wno-redundant-constraints
 
 test-suite spec

--- a/servant-jsaddle.cabal
+++ b/servant-jsaddle.cabal
@@ -1,5 +1,5 @@
 name:               servant-jsaddle
-version:            0.16
+version:            0.17
 synopsis:
   automatic derivation of querying functions for servant webservices for jsaddle
 

--- a/servant-jsaddle.cabal
+++ b/servant-jsaddle.cabal
@@ -47,20 +47,20 @@ library
   -- text and mtl are bundled starting with GHC-8.4
   build-depends:
       base          >=4.9      && <5
-    , bytestring    >=0.10.8.1
+    , bytestring    >=0.10.8.1 && <0.13
     , containers    >=0.5.7.1  && <0.7
-    , mtl           >=2.2.2
-    , text          >=1.2.3.0
-    , transformers  >=0.5.2.0
+    , mtl           >=2.2.2    && <2.4
+    , text          >=1.2.3.0  && <2.2
+    , transformers  >=0.5.2.0  && <0.7
 
   if impl(ghcjs -any) || arch(javascript)
     build-depends: ghcjs-base
 
   -- Servant dependencies.
   -- Strict dependency on `servant-client-core` as we re-export things.
-  build-depends:    servant-client-core >=0.16
+  build-depends:    servant-client-core >=0.16 && <0.21
   build-depends:
-      base-compat         >=0.10.5
+      base-compat         >=0.10.5 && <=0.13.1
     , case-insensitive    >=1.2.0.0 && <1.3
     , exceptions          >=0.10.0  && <0.11
     , ghcjs-dom           >=0.9.4.0 && <0.10
@@ -68,7 +68,7 @@ library
     , http-types          >=0.12.2  && <0.13
     , jsaddle             >=0.9.6.0 && <0.10
     , monad-control       >=1.0.2.3 && <1.1
-    , semigroupoids       >=5.3.1
+    , semigroupoids       >=5.3.1   && <6.1
     , string-conversions  >=0.3     && <0.5
     , transformers-base   >=0.4.4   && <0.5
 

--- a/servant-jsaddle.cabal
+++ b/servant-jsaddle.cabal
@@ -53,7 +53,7 @@ library
     , text          >=1.2.3.0
     , transformers  >=0.5.2.0
 
-  if impl(ghcjs -any)
+  if impl(ghcjs -any) || arch(javascript)
     build-depends: ghcjs-base
 
   -- Servant dependencies.
@@ -72,7 +72,7 @@ library
     , string-conversions  >=0.3     && <0.5
     , transformers-base   >=0.4.4   && <0.5
 
-  if impl(ghc >=8.0)
+  if impl(ghc >=8.0) || arch(javascript)
     ghc-options: -Wno-redundant-constraints
 
 test-suite spec
@@ -82,7 +82,7 @@ test-suite spec
   hs-source-dirs:   test
   main-is:          Spec.hs
 
-  if impl(ghcjs -any)
+  if impl(ghcjs -any) || arch(javascript)
     build-depends:
         base
       , servant-jsaddle

--- a/servant-jsaddle.cabal
+++ b/servant-jsaddle.cabal
@@ -46,21 +46,21 @@ library
   -- Bundled with GHC: Lower bound to not force re-installs
   -- text and mtl are bundled starting with GHC-8.4
   build-depends:
-      base          >=4.9      && <4.14
-    , bytestring    >=0.10.8.1 && <0.11
+      base          >=4.9      && <5
+    , bytestring    >=0.10.8.1
     , containers    >=0.5.7.1  && <0.7
-    , mtl           >=2.2.2    && <2.3
-    , text          >=1.2.3.0  && <1.3
-    , transformers  >=0.5.2.0  && <0.6
+    , mtl           >=2.2.2
+    , text          >=1.2.3.0
+    , transformers  >=0.5.2.0
 
   if impl(ghcjs -any)
     build-depends: ghcjs-base
 
   -- Servant dependencies.
   -- Strict dependency on `servant-client-core` as we re-export things.
-  build-depends:    servant-client-core >=0.16 && <0.16.1
+  build-depends:    servant-client-core >=0.16
   build-depends:
-      base-compat         >=0.10.5  && <0.12
+      base-compat         >=0.10.5
     , case-insensitive    >=1.2.0.0 && <1.3
     , exceptions          >=0.10.0  && <0.11
     , ghcjs-dom           >=0.9.4.0 && <0.10
@@ -68,7 +68,7 @@ library
     , http-types          >=0.12.2  && <0.13
     , jsaddle             >=0.9.6.0 && <0.10
     , monad-control       >=1.0.2.3 && <1.1
-    , semigroupoids       >=5.3.1   && <5.4
+    , semigroupoids       >=5.3.1
     , string-conversions  >=0.3     && <0.5
     , transformers-base   >=0.4.4   && <0.5
 


### PR DESCRIPTION
- Update the project to allow it to compile with newer versions of servant-client-core (while still being backwards-compatible).
- Modify cabal file so it compiles when using the new GHC JS backend.

Related to https://github.com/haskell-servant/servant-jsaddle/pull/6 (sorry I didn't see this earlier).